### PR TITLE
Remove duplicate requirements with flex; add sentencepiece

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch==1.8.1
 transformers==4.6.0
+sentencepiece==0.1.96
 pytorch-lightning==1.3.4
-hydra-core==1.1.0.dev2
-datasets==1.6.2


### PR DESCRIPTION
hydra-core and datatsets have different versions in https://github.com/allenai/flex/blob/main/requirements.txt. I also needed to install sentencepiece to get the repo to work on my machine.